### PR TITLE
75 fix filtlong bug when all reads removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.2]
+
+### Added
+
+### Fixed
+
+- Fixed `filtlong` bug that crashes pipeline when all reads are filtered out with `.branch` operator
+
+### Changed
+
 ## [v0.4.1]
 
 ### Added
@@ -12,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed version in nextflow.config
-- Fixed `filtlong` bug that crashes pipeline when all reads are filtered out with `.branch` operator
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
- - Fixed version in nextflow.config
+
+- Fixed version in nextflow.config
+- Fixed `filtlong` bug that crashes pipeline when all reads are filtered out with `.branch` operator
+
 ### Changed
 
 ## [v0.4.0]

--- a/conf/cmd.config
+++ b/conf/cmd.config
@@ -12,7 +12,7 @@
 
 process {
     executor                    = 'slurm'
-    queue                       = 'low'
+    queue                       = 'grace-high'
 }
 
 params {
@@ -20,7 +20,7 @@ params {
     config_profile_description  = 'CMD High performance profile'
 
     // Databases
-    db                          = '/fs1/pipelines/trana-dev/assets/databases/emu_database'
+    db                          = '/fs1/pipelines/trana/assets/databases/emu_database'
 
     // Limit resources so that this can run on GitHub Actions
     max_cpus                    = 60
@@ -38,4 +38,8 @@ singularity{
     enabled = true
     runOptions = '--bind /fs1/ --bind /fs2/ --bind /local/ --bind /mnt/beegfs/'
     cacheDir = "/fs1/resources/containers/"
+    env {
+        LC_ALL = 'C.UTF-8'
+        LANG = 'C.UTF-8'
+    }
 }

--- a/modules/nf-core/filtlong/main.nf
+++ b/modules/nf-core/filtlong/main.nf
@@ -22,13 +22,20 @@ process FILTLONG {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def short_reads = !shortreads ? "" : meta.single_end ? "-1 $shortreads" : "-1 ${shortreads[0]} -2 ${shortreads[1]}"
-    if ("$longreads" == "${prefix}.fastq.gz") error "Longread FASTQ input and output names are the same, set prefix in module configuration to disambiguate!"
     """
+    if [[ "${longreads}" == "${prefix}.fastq.gz" ]]; then
+        echo "ERROR: Longread FASTQ input and output names are the same. Set prefix in module configuration to disambiguate!" >&2
+        exit 1
+    fi
+
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
+
     filtlong \\
         $short_reads \\
         $args \\
         $longreads \\
-        2> >(tee ${prefix}.log >&2) \\
+        2>| >(tee ${prefix}.log >&2) \\
         | gzip -n > ${prefix}.fastq.gz
 
     cat <<-END_VERSIONS > versions.yml

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -55,7 +55,7 @@
                     "type": "string",
                     "default": "copy",
                     "description": "Method used to save pipeline results to output directory.",
-                    "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files.                                                                                                                                                                                                                        See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
+                    "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
                     "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
@@ -141,7 +141,7 @@
                     "type": "string",
                     "description": "Email address for completion summary.",
                     "fa_icon": "fas fa-envelope",
-                    "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then y                                                                                                                                                                                                                       ou don't need to specify this on the command line for every run.",
+                    "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
                     "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
                 },
                 "show_hidden_params": {
@@ -149,7 +149,7 @@
                     "fa_icon": "far fa-eye-slash",
                     "description": "Show all params when using `--help`",
                     "hidden": true,
-                    "help_text": "By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters.                                                                                                                                                                                                                       "
+                    "help_text": "By default, parameters set as _hidden_ in the schema are not shown on the command line when a user runs with `--help`. Specifying this option will tell the pipeline to show all parameters."
                 }
             }
         },
@@ -357,7 +357,7 @@
             "type": "object",
             "fa_icon": "fab fa-acquisitions-incorporated",
             "description": "Set the top limit for requested resources for any single job.",
-            "help_text": "If you are running on a smaller system, a pipeline step requesting more resources than are available may cause the Nextflow to stop the run with an error. These options allow you to cap the ma                                                                                                                                                                                                                       ximum resources requested by any single job so that the pipeline will run on your system.\n\nNote that you can not _increase_ the resources requested by any job using these options. For that you will need your ow                                                                                                                                                                                                                       n configuration file. See [the nf-core website](https://nf-co.re/usage/configuration) for details.",
+            "help_text": "If you are running on a smaller system, a pipeline step requesting more resources than are available may cause the Nextflow to stop the run with an error. These options allow you to cap the maximum resources requested by any single job so that the pipeline will run on your system.\n\nNote that you can not _increase_ the resources requested by any job using these options. For that you will need your own configuration file. See [the nf-core website](https://nf-co.re/usage/configuration) for details.",
             "properties": {
                 "max_cpus": {
                     "type": "integer",
@@ -392,7 +392,7 @@
             "type": "object",
             "fa_icon": "fas fa-university",
             "description": "Parameters used to describe centralised config profiles. These should not be edited.",
-            "help_text": "The centralised nf-core configuration profiles use a handful of pipeline parameters to describe themselves. This information is then printed to the Nextflow log when you run a pipeline. You sh                                                                                                                                                                                                                       ould not need to change these values when you run a pipeline.",
+            "help_text": "The centralised nf-core configuration profiles use a handful of pipeline parameters to describe themselves. This information is then printed to the Nextflow log when you run a pipeline. You should not need to change these values when you run a pipeline.",
             "properties": {
                 "custom_config_version": {
                     "type": "string",
@@ -406,7 +406,7 @@
                     "description": "Base directory for Institutional configs.",
                     "default": "https://raw.githubusercontent.com/nf-core/configs/master",
                     "hidden": true,
-                    "help_text": "If you're running offline, Nextflow will not be able to fetch the institutional config files from the internet. If you don't need them, then this is not a problem. If you do need them, you                                                                                                                                                                                                                        should download the files from the repo and tell Nextflow where to find them with this parameter.",
+                    "help_text": "If you're running offline, Nextflow will not be able to fetch the institutional config files from the internet. If you don't need them, then this is not a problem. If you do need them, you should download the files from the repo and tell Nextflow where to find them with this parameter.",
                     "fa_icon": "fas fa-users-cog"
                 },
                 "config_profile_name": {


### PR DESCRIPTION
## PR checklist
* `filtlong` process added important `|` missing.
* Added `.branch` operator to separate samples that don't pass filtlong filtering i.e. have no reads left after `filtlong` process.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
